### PR TITLE
chore: fix issue when building CH kernels

### DIFF
--- a/kernel-ch/Dockerfile
+++ b/kernel-ch/Dockerfile
@@ -34,7 +34,8 @@ WORKDIR ${LINUX_DIR}
 ARG KERNEL_CONFIG
 
 RUN curl -L -o .config ${KERNEL_CONFIG}
-RUN make LOCALVERSION= -j32
+#RUN make LOCALVERSION= -j32
+RUN KCFLAGS="-Wa,-mx86-used-note=no" make bzImage -j32
 
 RUN mkdir output
 RUN cp arch/x86/boot/compressed/vmlinux.bin ./output/vmlinux.bin&& \


### PR DESCRIPTION
Running into KernelMissingPvhHeader when using the kernel from the container. Made changes based on:

https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3222